### PR TITLE
Update to 24.08 runtime

### DIFF
--- a/org.mosh.mosh.appdata.xml
+++ b/org.mosh.mosh.appdata.xml
@@ -46,32 +46,35 @@
   <releases>
     <release version="1.4.0" date="2022-10-31"/>
     <release version="1.3.2" date="2017-07-22">
-      <p>Platform support:</p>
-      <ul>
-        <li>Explicitly enable binding to both IPv4 and IPv6 addresses.
-        (Giel van Schijndel)</li>
-        <li>Restore perl 5.8.8 support for RHEL5.  (Alexander Chernyakhovsky)</li>
-        <li>Make tests detect UTF-8 locale with a helper executable.  (John Hood)</li>
-        <li>Don't print /etc/motd on IllumOS.  (John Hood)</li>
-        <li>Print {,/var}/run/motd.dynamic on Ubuntu.  (John Hood)</li>
-        <li>Fix build on Haiku. (Adrien Destugues)</li>
-        <li>Disable unicode-later-combining.test for tmux 2.4.
-        This fixes build failures.  (John Hood)</li>
-      </ul>
+      <description>
+        <p>Platform support:</p>
+        <ul>
+          <li>Explicitly enable binding to both IPv4 and IPv6 addresses.
+          (Giel van Schijndel)</li>
+          <li>Restore perl 5.8.8 support for RHEL5.  (Alexander Chernyakhovsky)</li>
+          <li>Make tests detect UTF-8 locale with a helper executable.  (John Hood)</li>
+          <li>Don't print /etc/motd on IllumOS.  (John Hood)</li>
+          <li>Print {,/var}/run/motd.dynamic on Ubuntu.  (John Hood)</li>
+          <li>Fix build on Haiku. (Adrien Destugues)</li>
+          <li>Disable unicode-later-combining.test for tmux 2.4.
+          This fixes build failures.  (John Hood)</li>
+        </ul>
 
-      <p>Bug fixes:</p>
-      <ul>
-        <li>In tests, explicitly set 80x24 tmux window, for newer versions
-        of tmux.  (John Hood)</li>
-        <li>Work around JuiceSSH rendering bug.  (John Hood)</li>
-        <li>Do not move cursor for SCROLL UP and SCROLL DOWN--
-        fixes an issue with tmux 2.4.  (John Hood)</li>
-      </ul>
+        <p>Bug fixes:</p>
+        <ul>
+          <li>In tests, explicitly set 80x24 tmux window, for newer versions
+          of tmux.  (John Hood)</li>
+          <li>Work around JuiceSSH rendering bug.  (John Hood)</li>
+          <li>Do not move cursor for SCROLL UP and SCROLL DOWN--
+          fixes an issue with tmux 2.4.  (John Hood)</li>
+        </ul>
+      </description>
     </release>
   </releases>
   <screenshots>
     <screenshot type="default">
       <image>https://mosh.org/mosh.png</image>
+      <caption>A Mosh session</caption>
     </screenshot>
   </screenshots>
   <content_rating type="oars-1.1"/>

--- a/org.mosh.mosh.appdata.xml
+++ b/org.mosh.mosh.appdata.xml
@@ -44,7 +44,33 @@
   </description>
   <developer_name>Keith Winstein, John Hood, et al.</developer_name>
   <releases>
-    <release version="1.4.0" date="2022-10-31"/>
+    <release version="1.4.0" date="2022-10-31">
+      <url>https://mosh.org/mosh-1.4.0-released.html</url>
+      <description>
+        <p>New features:</p>
+        <ul>
+          <li>Support OSC 52 clipboard copy integration (Alex Cornejo)</li>
+          <li>Allow non-inserting prediction (--predict-overwrite) (John Hood)</li>
+          <li>Don't do prediction on large pastes into mosh-client (John Hood)</li>
+          <li>Add true color support (Kang Jianbin)</li>
+          <li>Add syslog logging of connections (Tom Judge)</li>
+          <li>If exec()ing the remote command fails, pause briefly (John Hood)</li>
+        </ul>
+
+        <p>Bug fixes:</p>
+
+        <ul>
+          <li>ignore unknown renditions (Keith Winstein)</li>
+          <li>Overlays were getting set to the wrong colors (John Hood)</li>
+          <li>Fix issue with incorrect true-color background erase colors (John Hood)</li>
+          <li>Use HAVE_UTEMPTER instead of HAVE_UPTEMPTER (Michael Jarvis)</li>
+          <li>Apply latest consecutive resize, not earliest (Peter Edwards)</li>
+          <li>Use CLOCK_MONOTONIC_RAW when available (Harry Sintonen)</li>
+          <li>Add tmux and alacritty to title_term_types (Naïm Favier)</li>
+          <li>Don't sometimes hang just after launching ssh (Kalle Samuels)</li>
+        </ul>
+      </description>
+    </release>
     <release version="1.3.2" date="2017-07-22">
       <description>
         <p>Platform support:</p>

--- a/org.mosh.mosh.yml
+++ b/org.mosh.mosh.yml
@@ -1,6 +1,6 @@
 app-id: org.mosh.mosh
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 command: mosh
 separate-locales: false

--- a/org.mosh.mosh.yml
+++ b/org.mosh.mosh.yml
@@ -77,14 +77,14 @@ modules:
       - --disable-server
     sources:
       - type: archive
-        url: https://mosh.org/mosh-1.4.0.tar.gz
+        url: https://github.com/mobile-shell/mosh/releases/download/mosh-1.4.0/mosh-1.4.0.tar.gz
         sha256: 872e4b134e5df29c8933dff12350785054d2fd2839b5ae6b5587b14db1465ddd
         x-checker-data:
           type: json
           url: https://api.github.com/repos/mobile-shell/mosh/releases/latest
           version-query: .tag_name | sub("^mosh-"; "")
           url-query: >-
-            "https://mosh.org/mosh-\($version).tar.gz"
+            .assets[] | select(.name=="mosh-" + $version + ".tar.gz") | .browser_download_url
       - type: file
         path: org.mosh.mosh.appdata.xml
     post-install:

--- a/org.mosh.mosh.yml
+++ b/org.mosh.mosh.yml
@@ -63,8 +63,8 @@ modules:
       - '*.pod'
     sources:
       - type: archive
-        url: https://www.cpan.org/src/5.0/perl-5.36.0.tar.xz
-        sha256: 0f386dccbee8e26286404b2cca144e1005be65477979beb9b1ba272d4819bcf0
+        url: https://www.cpan.org/src/5.0/perl-5.40.0.tar.gz
+        sha256: c740348f357396327a9795d3e8323bafd0fe8a5c7835fc1cbaba0cc8dfe7161f
       - type: script
         dest-filename: configure
         commands:


### PR DESCRIPTION
Also includes a Perl update, and a change to the Mosh download URL that was necessary to build the project.

I did not update protobuf. (That would probably be good to do.)